### PR TITLE
fix: resolve public image url for static hosting

### DIFF
--- a/components/LayoutHeader.vue
+++ b/components/LayoutHeader.vue
@@ -1,15 +1,17 @@
 <template>
   <header v-if="logoHeader">
-    <img :src="logoHeader" width="60" height="60" class="object-contain" />
+    <img :src="logoSrc" width="60" height="60" class="object-contain" />
   </header>
 </template>
 
 <script setup lang="ts">
-import { defineProps } from 'vue'
+import { defineProps, computed } from 'vue'
+import { resolveAssetUrl } from '@slidev/client/layoutHelper'
 
 const props = defineProps({
-    logoHeader: {
-      type: String,
-    },
-  })
+  logoHeader: {
+    type: String,
+  },
+})
+const logoSrc = computed(() => resolveAssetUrl(props.logoHeader))
 </script>

--- a/layouts/cover-logos.vue
+++ b/layouts/cover-logos.vue
@@ -5,9 +5,10 @@
         <slot />
       </div>
       <div class="w-1/2 flex items-center justify-center">
-        <div class="flex flex-wrap items-center justify-center p-4 w-72 h-72 rounded-full bg-gradient-to-r from-fuchsia-700 to-purple-800 dark:(from-white to-purple-50)">
+        <div
+          class="flex flex-wrap items-center justify-center p-4 w-72 h-72 rounded-full bg-gradient-to-r from-fuchsia-700 to-purple-800 dark:(from-white to-purple-50)">
           <div class="flex flex-wrap items-center justify-center -mr-2">
-            <figure v-for="(logo, i) in logos" :key="i" class="pr-2 pb-2">
+            <figure v-for="(logo, i) in logoSources" :key="i" class="pr-2 pb-2">
               <img :src="logo" :alt="`logo ${i}`" width="125" height="75" class="w-auto h-12 object-contain" />
             </figure>
           </div>
@@ -18,7 +19,8 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, defineComponent } from 'vue'
+import { defineProps, defineComponent, computed } from 'vue'
+import { resolveAssetUrl } from '@slidev/client/layoutHelper'
 import Default from './default.vue'
 
 const components = defineComponent({ Default })
@@ -27,4 +29,5 @@ const props = defineProps({
     type: Array,
   }
 })
+const logoSources = computed(() => props.logos.map(logo => resolveAssetUrl(logo)))
 </script>

--- a/layouts/image-center.vue
+++ b/layouts/image-center.vue
@@ -2,13 +2,15 @@
   <default class="image-center">
     <div class="flex flex-col">
       <slot />
-      <img :src="image" alt="Slide image" :width="imageWidth" :height="imageHeight" class="rounded-md shadow-lg  m-auto object-contain" />
+      <img :src="imageSrc" alt="Slide image" :width="imageWidth" :height="imageHeight"
+        class="rounded-md shadow-lg  m-auto object-contain" />
     </div>
   </default>
 </template>
 
 <script setup lang="ts">
-import { defineProps, defineComponent } from 'vue'
+import { defineProps, defineComponent, computed } from 'vue'
+import { resolveAssetUrl } from '@slidev/client/layoutHelper'
 import Default from '../layouts/default.vue'
 
 const components = defineComponent({ Default })
@@ -23,4 +25,5 @@ const props = defineProps({
     type: String,
   },
 })
+const imageSrc = computed(() => resolveAssetUrl(props.image))
 </script>

--- a/layouts/intro.vue
+++ b/layouts/intro.vue
@@ -2,7 +2,8 @@
   <default class="intro" :logoHeader="logoHeader">
     <div class="flex items-center">
       <figure class="w-1/2 px-12">
-        <img :src="introImage" height="312" width="312" class="rounded-full p-2 bg-gradient-to-r from-fuchsia-700 to-purple-800 dark:(from-white to-purple-50)">
+        <img :src="imageSrc" height="312" width="312"
+          class="rounded-full p-2 bg-gradient-to-r from-fuchsia-700 to-purple-800 dark:(from-white to-purple-50)">
       </figure>
       <div class="w-1/2">
         <slot />
@@ -12,7 +13,8 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, defineComponent } from 'vue'
+import { defineProps, defineComponent, computed } from 'vue'
+import { resolveAssetUrl } from '@slidev/client/layoutHelper'
 import Default from '../layouts/default.vue'
 
 const components = defineComponent({ Default })
@@ -21,4 +23,5 @@ const props = defineProps({
     type: String,
   },
 })
+const imageSrc = computed(() => resolveAssetUrl(props.introImage))
 </script>

--- a/layouts/new-section.vue
+++ b/layouts/new-section.vue
@@ -2,7 +2,7 @@
   <default class="new-section" :logoHeader="logoHeader">
     <div class="flex items-center">
       <figure class="w-1/2">
-        <img :src="sectionImage" alt="new section" width="400" height="400" class="ml-auto" />
+        <img :src="imageSrc" alt="new section" width="400" height="400" class="ml-auto" />
       </figure>
       <div class="w-1/2 text-right pr-12">
         <slot />
@@ -12,7 +12,8 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, defineComponent } from 'vue'
+import { defineProps, defineComponent, computed } from 'vue'
+import { resolveAssetUrl } from '@slidev/client/layoutHelper'
 import Default from './default.vue'
 import SectionIllustration from '../public/section-illustration.svg'
 
@@ -23,12 +24,14 @@ const props = defineProps({
     default: SectionIllustration
   },
 })
+const imageSrc = computed(() => resolveAssetUrl(props.sectionImage))
 </script>
 
 <style>
 .slidev-layout.new-section {
   @apply bg-gradient-to-r from-fuchsia-700 to-purple-800 text-white;
 }
+
 .slidev-layout.new-section *,
 .slidev-layout.new-section h1,
 .slidev-layout.new-section h2,
@@ -38,5 +41,7 @@ const props = defineProps({
 .slidev-layout.new-section h6,
 .slidev-layout.new-section p,
 .slidev-layout.new-section strong,
-.slidev-layout.new-section a { @apply text-white; }
+.slidev-layout.new-section a {
+  @apply text-white;
+}
 </style>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@slidev/cli": "^0.31.2",
+    "@slidev/client": "^0.31.4",
     "@slidev/theme-default": "^0.21.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,11 @@
   resolved "https://registry.yarnpkg.com/@antfu/utils/-/utils-0.5.1.tgz#7eb6764878adb715daff20019e5a15fd63d93342"
   integrity sha512-8Afo0+xvYe1K8Wm4xHTymfTkpzy36aaqDvhXIayUwl+mecMG9Xzl3XjXa6swG6Bk8FBeQ646RyvmsYt6+2Be9g==
 
+"@antfu/utils@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@antfu/utils/-/utils-0.5.2.tgz#8c2d931ff927be0ebe740169874a3d4004ab414b"
+  integrity sha512-CQkeV+oJxUazwjlHD0/3ZD08QWKuGQkhnrKo3e6ly5pd48VUpXbb77q0xMU4+vc2CkJnDS02Eq/M9ugyX20XZA==
+
 "@babel/parser@^7.16.4":
   version "7.17.10"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.10.tgz#873b16db82a8909e0fbd7f115772f4b739f6ce78"
@@ -172,12 +177,50 @@
     vue-starport "^0.2.10"
     windicss "^3.5.1"
 
+"@slidev/client@^0.31.4":
+  version "0.31.4"
+  resolved "https://registry.yarnpkg.com/@slidev/client/-/client-0.31.4.tgz#85ab7ddaf1e76cba78dd300579a226e217098d64"
+  integrity sha512-LA3ahdphQKBSGnn2Mgy7R4cBQ0LNsjRsDkGOguTV2s1MJz0zx7flkHC0ngSKe6fmq7bzpotOhYkuW96Ww+9uew==
+  dependencies:
+    "@antfu/utils" "^0.5.2"
+    "@slidev/parser" "0.31.4"
+    "@slidev/types" "0.31.4"
+    "@vueuse/core" "^8.4.2"
+    "@vueuse/head" "^0.7.6"
+    "@vueuse/motion" "^2.0.0-beta.18"
+    codemirror "^5.65.3"
+    defu "^6.0.0"
+    drauu "^0.3.0"
+    file-saver "^2.0.5"
+    js-base64 "^3.7.2"
+    js-yaml "^4.1.0"
+    katex "^0.15.3"
+    mermaid "^9.1.1"
+    monaco-editor "^0.33.0"
+    nanoid "^3.3.4"
+    prettier "^2.6.2"
+    recordrtc "^5.6.2"
+    resolve "^1.22.0"
+    vite-plugin-windicss "^1.8.4"
+    vue "^3.2.33"
+    vue-router "^4.0.15"
+    vue-starport "^0.2.10"
+    windicss "^3.5.3"
+
 "@slidev/parser@0.31.2":
   version "0.31.2"
   resolved "https://registry.yarnpkg.com/@slidev/parser/-/parser-0.31.2.tgz#c6c2aee4d1cb11824dd31ddffa348d4944f9ed46"
   integrity sha512-NklmVD1dpUE1gqqV7SJ9DT+OeO4xL2iYREATo4TCvYrOWzAfwTHPFqFBbraqLK/m7JTwBOOWieRLj5JMIv07rA==
   dependencies:
     "@slidev/types" "0.31.2"
+    js-yaml "^4.1.0"
+
+"@slidev/parser@0.31.4":
+  version "0.31.4"
+  resolved "https://registry.yarnpkg.com/@slidev/parser/-/parser-0.31.4.tgz#fe667b8aff118f3ba68903417520fde255b4d445"
+  integrity sha512-SHdkZfTPOAlGtSnaI99zRTezqu4txisqN6gM0btbvllhZhyHkwfAkQ8bSWaQtPYbCkQXC3J2mS4DTDGO8lEOvg==
+  dependencies:
+    "@slidev/types" "0.31.4"
     js-yaml "^4.1.0"
 
 "@slidev/theme-default@^0.21.2":
@@ -194,6 +237,11 @@
   version "0.31.2"
   resolved "https://registry.yarnpkg.com/@slidev/types/-/types-0.31.2.tgz#9c2c743f1f0a4b6e1436d33c0d706c03e4097506"
   integrity sha512-PUmq0QyCiH0YEkOGl8iik64VATKU5PoSknCN/wUb52sOXmG/uSlGHyxeMHlarNQVJbZh3ih1T8hDoI2gj3ZIOg==
+
+"@slidev/types@0.31.4":
+  version "0.31.4"
+  resolved "https://registry.yarnpkg.com/@slidev/types/-/types-0.31.4.tgz#01b16fea725a6ad06c14fb5a9c0378be2254b954"
+  integrity sha512-K4xKC+NiwNelU+W+9DBTwJfJ0WKQZkQglHg5RGilIKru+krzJ7iMtaz8afpK/SnvcS1lFmuoL+w1x2nOucePPg==
 
 "@slidev/types@^0.22.7":
   version "0.22.7"
@@ -1938,6 +1986,11 @@ khroma@^1.4.1:
   resolved "https://registry.yarnpkg.com/khroma/-/khroma-1.4.1.tgz#ad6a5b6a972befc5112ce5129887a1a83af2c003"
   integrity sha512-+GmxKvmiRuCcUYDgR7g5Ngo0JEDeOsGdNONdU2zsiBQaK4z19Y2NvXqfEDE0ZiIrg45GTZyAnPLVsLZZACYm3Q==
 
+khroma@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/khroma/-/khroma-2.0.0.tgz#7577de98aed9f36c7a474c4d453d94c0d6c6588b"
+  integrity sha512-2J8rDNlQWbtiNYThZRvmMv5yt44ZakX+Tz5ZIp/mN1pt4snn+m030Va5Z4v8xA0cQFDXBwO/8i42xL4QPsVk3g==
+
 kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
@@ -2048,6 +2101,21 @@ mermaid@^9.0.1:
     dompurify "2.3.6"
     graphlib "^2.1.8"
     khroma "^1.4.1"
+    moment-mini "^2.24.0"
+    stylis "^4.0.10"
+
+mermaid@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-9.1.1.tgz#5d3d330ca4adf7f3c8ca51095f8bb2f0fb1a93bb"
+  integrity sha512-2RVD+WkzZ4VDyO9gQvQAuQ/ux2gLigJtKDTlbwjYqOR/NwsVzTSfGm/kx648/qWJsg6Sv04tE9BWCO8s6a+pFA==
+  dependencies:
+    "@braintree/sanitize-url" "^6.0.0"
+    d3 "^7.0.0"
+    dagre "^0.8.5"
+    dagre-d3 "^0.6.4"
+    dompurify "2.3.6"
+    graphlib "^2.1.8"
+    khroma "^2.0.0"
     moment-mini "^2.24.0"
     stylis "^4.0.10"
 
@@ -2922,6 +2990,11 @@ windicss@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/windicss/-/windicss-3.5.2.tgz#2b049bc1135a83f5b829974f72f7e51176e02721"
   integrity sha512-Vy06iCcKXjR9izEViwIcwdaZHouzNWmjqWmVt3lyfZVNm6hWz6ME6s+6pIwrHMbylbal9hW3M9LRbN9mzFhccQ==
+
+windicss@^3.5.3:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/windicss/-/windicss-3.5.4.tgz#e55b9e1803d63c2256ddb94e60af8f582489b402"
+  integrity sha512-x2Iu0a69dtNiKHMkR886lx0WKbZI5GqvXyvGBCJ2VA6rcjKYjnzCA/Ljd6hNQBfqlkSum8J+qAVcCfLzQFI4rQ==
 
 wrap-ansi@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
First of all, thanks for creating this awesome theme! 👏 I really enjoyed using to create a [recent presentation](https://hipsterbrown.github.io/becoming-a-form-wizard/1). 

I ran into a small issue when building the slides to host on GitHub Pages where any image in the `public/` directory would not use the [base path](https://sli.dev/guide/hosting.html#base-path) specified as a command line argument. After digging into the Slidev source, I found the [layoutHelper](https://github.com/slidevjs/slidev/blob/main/packages/client/layoutHelper.ts#L6) module with a `resolveAssetUrl` function to solve the issue.

I've updated the appropriate layouts and components to use the referenced helper in this PR.

_Apologies for any auto-formatting done by my editor. I can revert the formatting changes if you'd like_