### PR TITLE
fix: correct default sectionImage path in new-section layout

### DIFF
--- a/layouts/new-section.vue
+++ b/layouts/new-section.vue
@@ -25,7 +25,7 @@ import Default from "./default.vue";
 const props = defineProps({
   sectionImage: {
     type: String,
-    default: "../public/section-illustration.svg",
+    default: "/theme/section-illustration.svg",
   },
 });
 const imageSrc = computed(() => resolveAssetUrl(props.sectionImage));


### PR DESCRIPTION
## Problem

The default value for `sectionImage` in `layouts/new-section.vue` is `../public/section-illustration.svg`. Since this path does not start with `/`, `resolveAssetUrl` passes it through unchanged. The browser then tries to resolve it relative to the page URL, which fails — leaving the section slide with no illustration.

Reported in #8.

## Root Cause: Regression in 1.1.2

In 1.1.1, the layout imported `resolveAssetUrl` from `@slidev/client/layoutHelper`, which handled the relative path correctly. PR #6 replaced this with a local `../layoutHelper`, whose implementation only processes paths starting with `/`:

```ts
export function resolveAssetUrl(url: string) {
  if (url.startsWith('/'))
    return import.meta.env.BASE_URL + url.slice(1)
  return url  // ../public/... falls through here, broken in browser
}
```

The default value `../public/section-illustration.svg` was never updated to match, causing it to break in 1.1.2.

## How Slidev Serves Theme Public Assets

Slidev uses `vite-plugin-static-copy` to serve theme `public/` assets under the `/theme/` path (not `/`). So `section-illustration.svg` from the theme package is available at `/theme/section-illustration.svg`.

## Fix

Change the default from `../public/section-illustration.svg` to `/theme/section-illustration.svg`:

```diff
- default: "../public/section-illustration.svg",
+ default: "/theme/section-illustration.svg",
```

This allows `sectionImage` to be safely omitted in frontmatter and the illustration will render correctly.

Fixes #8